### PR TITLE
Added LDAP configuration and some small bugfixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ENV \
 RUN \
     apt-get -y update \
     && apt-get install --no-install-recommends -y \
+        crudini \
         procps \
         wget \
         python2.7 \

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Seafile docker image based on Debian
 * Auto import previous installation, including non docker installation
 * Support FASTCGI mode
 * Upgrade Seafile with one simple command
+* Support LDAP configuration
 
 ## Supported tags ##
 Tags of this image follow Seafile version:
@@ -82,15 +83,15 @@ Tags of this image follow Seafile version:
 
   * **SEAFILE_ADMIN_PASSWORD** (required): password for the admin account
 
-  * **SEAFILE_LDAP_URL** (optional): LDAP URL (e.g. ldap://openldap)
+  * **LDAP_URL** (optional): LDAP URL (e.g. ldap://openldap)
 
-  * **SEAFILE_LDAP_BASE** (required if **SEAFILE_LDAP_URL** ist set): LDAP BASE (e.g. ou=people,dc=example,dc=org)
+  * **LDAP_BASE** (required if **LDAP_URL** ist set): LDAP BASE (e.g. ou=people,dc=example,dc=org)
 
-  * **SEAFILE_LDAP_LOGIN_ATTR** (required if **SEAFILE_LDAP_URL** ist set): LDAP Login attribute (e.g. mail)
+  * **LDAP_LOGIN_ATTR** (required if **LDAP_URL** ist set): LDAP Login attribute (e.g. mail)
 
-  * **SEAFILE_LDAP_USER_DN** (optional): LDAP user DN (e.g. cn=admin,dc=example,dc=org)
+  * **LDAP_USER_DN** (optional): LDAP user DN (e.g. cn=admin,dc=example,dc=org)
 
-  * **SEAFILE_LDAP_PASSWORD** (optional): LDAP user password
+  * **LDAP_PASSWORD** (optional): LDAP user password
 
 
 ## docker-compose.yml example ##

--- a/README.md
+++ b/README.md
@@ -112,11 +112,11 @@ Tags of this image follow Seafile version:
        - MYSQL_ROOT_PASSWORD=passw0rd!
        - SEAFILE_ADMIN=admin@domain.com
        - SEAFILE_ADMIN_PASSWORD=passw00rd
-#       - SEAFILE_LDAP_URL=ldap://openldap
-#       - SEAFILE_LDAP_BASE=ou=people,dc=example,dc=org
-#       - SEAFILE_LDAP_LOGIN_ATTR=mail
-#       - SEAFILE_LDAP_USER_DN=cn=admin,dc=example,dc=org
-#       - SEAFILE_LDAP_PASSWORD=ldap_passw0rd
+       - LDAP_URL=ldap://openldap
+       - LDAP_BASE=ou=people,dc=example,dc=org
+       - LDAP_LOGIN_ATTR=mail
+       - LDAP_USER_DN=cn=admin,dc=example,dc=org
+       - LDAP_PASSWORD=ldap_passw0rd
       volumes:
        - ./seafile:/seafile
       depends_on:

--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ Tags of this image follow Seafile version:
 
   * **SEAFILE_LDAP_URL** (optional): LDAP URL (e.g. ldap://openldap)
 
-  * **SEAFILE_LDAP_BASE** (required if **SEAFILE_LDAP_URL** ist set): LDAP BASE (e.g. ou=People,dc=example,dc=org)
+  * **SEAFILE_LDAP_BASE** (required if **SEAFILE_LDAP_URL** ist set): LDAP BASE (e.g. ou=people,dc=example,dc=org)
 
   * **SEAFILE_LDAP_LOGIN_ATTR** (required if **SEAFILE_LDAP_URL** ist set): LDAP Login attribute (e.g. mail)
 
-  * **SEAFILE_LDAP_USER_DN** (optional): LDAP user DN
+  * **SEAFILE_LDAP_USER_DN** (optional): LDAP user DN (e.g. cn=admin,dc=example,dc=org)
 
   * **SEAFILE_LDAP_PASSWORD** (optional): LDAP user password
 
@@ -113,9 +113,9 @@ Tags of this image follow Seafile version:
        - SEAFILE_ADMIN=admin@domain.com
        - SEAFILE_ADMIN_PASSWORD=passw00rd
 #       - SEAFILE_LDAP_URL=ldap://openldap
-#       - SEAFILE_LDAP_BASE=ou=People,dc=example,dc=org
+#       - SEAFILE_LDAP_BASE=ou=people,dc=example,dc=org
 #       - SEAFILE_LDAP_LOGIN_ATTR=mail
-#       - SEAFILE_LDAP_USER_DN=user_dn
+#       - SEAFILE_LDAP_USER_DN=cn=admin,dc=example,dc=org
 #       - SEAFILE_LDAP_PASSWORD=ldap_passw0rd
       volumes:
        - ./seafile:/seafile

--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ Tags of this image follow Seafile version:
 
   * **SEAFILE_ADMIN_PASSWORD** (required): password for the admin account
 
+  * **SEAFILE_LDAP_URL** (optional): LDAP URL (e.g. ldap://openldap)
+
+  * **SEAFILE_LDAP_BASE** (required if **SEAFILE_LDAP_URL** ist set): LDAP BASE (e.g. ou=People,dc=example,dc=org)
+
+  * **SEAFILE_LDAP_LOGIN_ATTR** (required if **SEAFILE_LDAP_URL** ist set): LDAP Login attribute (e.g. mail)
+
+  * **SEAFILE_LDAP_USER_DN** (optional): LDAP user DN
+
+  * **SEAFILE_LDAP_PASSWORD** (optional): LDAP user password
+
 
 ## docker-compose.yml example ##
   ```yml
@@ -102,8 +112,13 @@ Tags of this image follow Seafile version:
        - MYSQL_ROOT_PASSWORD=passw0rd!
        - SEAFILE_ADMIN=admin@domain.com
        - SEAFILE_ADMIN_PASSWORD=passw00rd
+#       - SEAFILE_LDAP_URL=ldap://openldap
+#       - SEAFILE_LDAP_BASE=ou=People,dc=example,dc=org
+#       - SEAFILE_LDAP_LOGIN_ATTR=mail
+#       - SEAFILE_LDAP_USER_DN=user_dn
+#       - SEAFILE_LDAP_PASSWORD=ldap_passw0rd
       volumes:
-       - ./seafile:/home/seafile
+       - ./seafile:/seafile
       depends_on:
        - mariadb
 

--- a/script/start.sh
+++ b/script/start.sh
@@ -51,20 +51,20 @@ setup_seahub(){
 }
 
 setup_ldap(){
-	if [ -n "${SEAFILE_LDAP_URL}" ]; then
+	if [ -n "${LDAP_URL}" ]; then
 		log_info "Configuring LDAP"
-		check_require "SEAFILE_LDAP_BASE" $SEAFILE_LDAP_BASE
-		check_require "SEAFILE_LDAP_LOGIN_ATTR" $SEAFILE_LDAP_LOGIN_ATTR
-		crudini --set $EXPOSED_ROOT_DIR/conf/ccnet.conf LDAP HOST ${SEAFILE_LDAP_URL}
-		crudini --set $EXPOSED_ROOT_DIR/conf/ccnet.conf LDAP BASE ${SEAFILE_LDAP_BASE}
-		crudini --set $EXPOSED_ROOT_DIR/conf/ccnet.conf LDAP LOGIN_ATTR ${SEAFILE_LDAP_LOGIN_ATTR}
-		if [ -n "${SEAFILE_LDAP_USER_DN}" ]; then
-			crudini --set $EXPOSED_ROOT_DIR/conf/ccnet.conf LDAP USER_DN ${SEAFILE_LDAP_USER_DN}
+		check_require "LDAP_BASE" $LDAP_BASE
+		check_require "LDAP_LOGIN_ATTR" $LDAP_LOGIN_ATTR
+		crudini --set $EXPOSED_ROOT_DIR/conf/ccnet.conf LDAP HOST ${LDAP_URL}
+		crudini --set $EXPOSED_ROOT_DIR/conf/ccnet.conf LDAP BASE ${LDAP_BASE}
+		crudini --set $EXPOSED_ROOT_DIR/conf/ccnet.conf LDAP LOGIN_ATTR ${LDAP_LOGIN_ATTR}
+		if [ -n "${LDAP_USER_DN}" ]; then
+			crudini --set $EXPOSED_ROOT_DIR/conf/ccnet.conf LDAP USER_DN ${LDAP_USER_DN}
 		else
 			crudini --del $EXPOSED_ROOT_DIR/conf/ccnet.conf LDAP USER_DN
 		fi
-		if [ -n "${SEAFILE_LDAP_PASSWORD}" ]; then
-			crudini --set $EXPOSED_ROOT_DIR/conf/ccnet.conf LDAP PASSWORD ${SEAFILE_LDAP_PASSWORD}
+		if [ -n "${LDAP_PASSWORD}" ]; then
+			crudini --set $EXPOSED_ROOT_DIR/conf/ccnet.conf LDAP PASSWORD ${LDAP_PASSWORD}
 		else
 			crudini --del $EXPOSED_ROOT_DIR/conf/ccnet.conf LDAP PASSWORD
 		fi


### PR DESCRIPTION
I added a possibility to configure LDAP using environment variables.
More information on this here: https://manual.seafile.com/deploy/using_ldap.html

A small bugfix: 
I moved `wait_for_db` out of  `if [[ ! -e $LATEST_SERVER_DIR ]]` so that it always runs on startup.
Otherwise `docker-compose down` and `docker-compose up` resulted in an error that mysql was not running.

Moreover I fixed the docker-compose example from `./seafile:/home/seafile` to `./seafile:/seafile` 